### PR TITLE
Feature/multiple client addresses

### DIFF
--- a/WgServerforWindows/Models/ClientConfiguration.cs
+++ b/WgServerforWindows/Models/ClientConfiguration.cs
@@ -53,7 +53,7 @@ namespace WgServerforWindows.Models
                     WaitCursor.SetOverrideCursor(Cursors.Wait);
 
                     var serverAddresses = serverConfiguration.AddressProperty.Value
-                        .Split(new[] { ',' })
+                        .Split(',')
                         .Select(a => IPNetwork.Parse(a.Trim()))
                         .ToList(); // Prevent multiple enumeration
 

--- a/WgServerforWindows/Models/ClientConfiguration.cs
+++ b/WgServerforWindows/Models/ClientConfiguration.cs
@@ -58,7 +58,7 @@ namespace WgServerforWindows.Models
                         .ToList(); // Prevent multiple enumeration
 
                     var currentClientAddresses = prop.Value
-                        .Split(new[] { ',' })
+                        .Split(',')
                         .Select(a =>
                         {
                             IPAddress.TryParse(a.Trim(), out var address);

--- a/WgServerforWindows/Models/ServerConfiguration.cs
+++ b/WgServerforWindows/Models/ServerConfiguration.cs
@@ -35,7 +35,7 @@ namespace WgServerforWindows.Models
                 Validate = obj =>
                 {
                     // Multiple server addresses are supported, so validate all of them
-                    foreach (string address in obj.Value.Split(new[] { ',' }).Select(a => a.Trim()))
+                    foreach (string address in obj.Value.Split(',').Select(a => a.Trim()))
                     {
                         if (IPNetwork.TryParse(address, out _) == false)
                         {

--- a/WgServerforWindows/Models/ServerConfiguration.cs
+++ b/WgServerforWindows/Models/ServerConfiguration.cs
@@ -41,16 +41,13 @@ namespace WgServerforWindows.Models
                         {
                             return Resources.NetworkAddressValidationError;
                         }
-                        else // TryParse succeeded
+                        // IPNetwork.TryParse recognizes single IP addresses as CIDR (with 8 mask).
+                        // This is not good, because we want an explicit CIDR for the server.
+                        // Therefore, if IPNetwork.TryParse succeeds, and IPAddress.TryParse also succeeds, we have a problem.
+                        if (IPAddress.TryParse(address, out _))
                         {
-                            // IPNetwork.TryParse recognizes single IP addresses as CIDR (with 8 mask).
-                            // This is not good, because we want an explicit CIDR for the server.
-                            // Therefore, if IPNetwork.TryParse succeeds, and IPAddress.TryParse also succeeds, we have a problem.
-                            if (IPAddress.TryParse(address, out _))
-                            {
-                                // This is just a regular address. We want CIDR.
-                                return Resources.NetworkAddressValidationError;
-                            }
+                            // This is just a regular address. We want CIDR.
+                            return Resources.NetworkAddressValidationError;
                         }
                     }
 

--- a/WgServerforWindows/Models/ServerConfiguration.cs
+++ b/WgServerforWindows/Models/ServerConfiguration.cs
@@ -34,25 +34,27 @@ namespace WgServerforWindows.Models
             {
                 Validate = obj =>
                 {
-                    string result = default;
-
-                    if (IPNetwork.TryParse(obj.Value, out _) == false)
+                    // Multiple server addresses are supported, so validate all of them
+                    foreach (string address in obj.Value.Split(new[] { ',' }).Select(a => a.Trim()))
                     {
-                        result = Resources.NetworkAddressValidationError;
-                    }
-                    else // TryParse succeeded
-                    {
-                        // IPNetwork.TryParse recognizes single IP addresses as CIDR (with 8 mask).
-                        // This is not good, because we want an explicit CIDR for the server.
-                        // Therefore, if IPNetwork.TryParse succeeds, and IPAddress.TryParse also succeeds, we have a problem.
-                        if (IPAddress.TryParse(obj.Value, out _))
+                        if (IPNetwork.TryParse(address, out _) == false)
                         {
-                            // This is just a regular address. We want CIDR.
-                            result = Resources.NetworkAddressValidationError;
+                            return Resources.NetworkAddressValidationError;
+                        }
+                        else // TryParse succeeded
+                        {
+                            // IPNetwork.TryParse recognizes single IP addresses as CIDR (with 8 mask).
+                            // This is not good, because we want an explicit CIDR for the server.
+                            // Therefore, if IPNetwork.TryParse succeeds, and IPAddress.TryParse also succeeds, we have a problem.
+                            if (IPAddress.TryParse(address, out _))
+                            {
+                                // This is just a regular address. We want CIDR.
+                                return Resources.NetworkAddressValidationError;
+                            }
                         }
                     }
 
-                    return result;
+                    return default;
                 }
             };
 


### PR DESCRIPTION
* Validate all Server Addresses instead of just the first 
* When auto-generating Client Addresses, populate one from each Server Address subnet
  * Do not overwrite any addresses that are already valid