### PR TITLE
For #70: Handle null client address

### DIFF
--- a/WgServerforWindows/Models/ClientConfiguration.cs
+++ b/WgServerforWindows/Models/ClientConfiguration.cs
@@ -57,16 +57,16 @@ namespace WgServerforWindows.Models
                         .Select(a => IPNetwork.Parse(a.Trim()))
                         .ToList(); // Prevent multiple enumeration
 
-                    var currentClientAddresses = prop.Value
+                    var currentClientAddresses = (prop.Value?
                         .Split(',')
                         .Select(a =>
                         {
                             IPAddress.TryParse(a.Trim(), out var address);
                             return address;
                         })
-                        .Where(a => a != null)
+                        .Where(a => a != null) ?? Enumerable.Empty<IPAddress>())
                         .ToList(); // Prevent multiple enumeration
-
+                    
                     var newClientAddresses = new HashSet<string>();
                     var serverAddressesToConsider = new List<IPNetwork>(serverAddresses); // Copy
 

--- a/WgServerforWindows/Models/ClientConfiguration.cs
+++ b/WgServerforWindows/Models/ClientConfiguration.cs
@@ -66,7 +66,6 @@ namespace WgServerforWindows.Models
                         })
                         .Where(a => a != null) ?? Enumerable.Empty<IPAddress>())
                         .ToList(); // Prevent multiple enumeration
-                    
                     var newClientAddresses = new HashSet<string>();
                     var serverAddressesToConsider = new List<IPNetwork>(serverAddresses); // Copy
 

--- a/WgServerforWindows/Models/ClientConfiguration.cs
+++ b/WgServerforWindows/Models/ClientConfiguration.cs
@@ -66,6 +66,7 @@ namespace WgServerforWindows.Models
                         })
                         .Where(a => a != null) ?? Enumerable.Empty<IPAddress>())
                         .ToList(); // Prevent multiple enumeration
+
                     var newClientAddresses = new HashSet<string>();
                     var serverAddressesToConsider = new List<IPNetwork>(serverAddresses); // Copy
 

--- a/WgServerforWindows/Models/UnhandledErrorWindowModel.cs
+++ b/WgServerforWindows/Models/UnhandledErrorWindowModel.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Windows;
 using System.Windows.Input;
 using GalaSoft.MvvmLight;
@@ -42,7 +44,18 @@ namespace WgServerforWindows.Models
                 exception = exception.InnerException;
             }
 
-            Clipboard.SetText(exceptionText.ToString());
+            // This can help to alleviate issues opening the clipboard like CLIPBRD_E_CANT_OPEN
+            // See: https://stackoverflow.com/a/69081 
+            foreach (var _ in Enumerable.Range(0, 10))
+            {
+                try
+                {
+                    Clipboard.SetText(exceptionText.ToString());
+                    break;
+                }
+                catch { }
+                Thread.Sleep(10);
+            }
         });
         private RelayCommand _copyErrorCommand;
     }


### PR DESCRIPTION
This handles having a null client address property (#70).

I also added some clipboard handling, although I wasn't able to reproduce that error,

About the `StringSplitOptions.RemoveEmptyEntries` option, I don't think that would provide much improvement. That only removes completely empty entries but doesn't trim non-empty entries. There is a newer option, `TrimEntries`, that does the latter, but it is only available in .NET 5+, which I have not upgraded this project to yet. Here's some sample code which hopefully demonstrates what I'm saying.

| ![image](https://user-images.githubusercontent.com/7417301/210783966-4b28c9d7-5373-4887-9b10-6bc3fb723986.png) |
| - |

@xeptore for review